### PR TITLE
Transition from proton to wine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,7 @@ dependencies = [
  "serde_json",
  "tar",
  "tokio",
+ "whatadistro",
  "wincompatlib",
  "xz2",
 ]
@@ -3962,6 +3963,12 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "whatadistro"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c97ebad4f59809511083f2161587445631bff21bb78d9e046b9ca5b2d05d913"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "tar",
  "tokio",
  "wincompatlib",
+ "xz2",
 ]
 
 [[package]]
@@ -2068,6 +2069,17 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "memchr"
@@ -4267,6 +4279,15 @@ checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]

--- a/babylonia-terminal-cli/src/game.rs
+++ b/babylonia-terminal-cli/src/game.rs
@@ -24,6 +24,30 @@ pub async fn run(
     let mut wine_component: Option<WineComponent> = None;
     let mut wine: Option<Wine> = None;
 
+    // Deleting old setup
+    if None == GameConfig::get_config().await.launcher_version {
+        info!("You seem to have the old setup to play the game.");
+        info!("do you want to delete it to setup the new one ? (y/n) (default - yes): ");
+
+        let input = BufReader::new(tokio::io::stdin())
+            .lines()
+            .next_line()
+            .await
+            .unwrap();
+
+        if None == input
+            || Some("".to_string()) == input
+            || Some("y".to_string()) == input
+            || Some("yes".to_string()) == input
+        {
+            info!("Deleting old setup...");
+            babylonia_terminal_sdk::utils::remove_setup().await;
+            info!("done!");
+        } else {
+            info!("Keeping old setup...");
+        }
+    }
+
     loop {
         let state_result = GameState::get_current_state().await;
         if let Err(error) = state_result {

--- a/babylonia-terminal-cli/src/game.rs
+++ b/babylonia-terminal-cli/src/game.rs
@@ -3,7 +3,7 @@ use std::{path::PathBuf, str::FromStr, sync::Arc};
 use babylonia_terminal_sdk::{
     components::{
         dxvk_component::{DXVK_DEV, DXVK_REPO},
-        proton_component::{ProtonComponent, PROTON_DEV, PROTON_REPO},
+        wine_component::{WineComponent, WINE_DEV, WINE_REPO},
     },
     game_config::GameConfig,
     game_manager::{EnvironmentVariable, GameManager},
@@ -21,8 +21,8 @@ pub async fn run(
     env_vars: Vec<EnvironmentVariable>,
     show_logs: bool,
 ) {
-    let mut proton_component: Option<ProtonComponent> = None;
-    let mut proton: Option<Proton> = None;
+    let mut wine_component: Option<WineComponent> = None;
+    let mut wine: Option<Wine> = None;
 
     loop {
         let state_result = GameState::get_current_state().await;
@@ -32,40 +32,42 @@ pub async fn run(
         }
         let state = state_result.unwrap();
 
-        if state != GameState::ProtonNotInstalled && proton == None {
-            let proton_component = ProtonComponent::new(GameConfig::get_config_directory().await);
-            match proton_component.init_proton() {
-                Ok(p) => proton = Some(p),
+        if state != GameState::WineNotInstalled && wine == None {
+            let wine_component = WineComponent::new(GameConfig::get_config_directory().await);
+            match wine_component.init_wine() {
+                Ok(p) => wine = Some(p),
                 Err(err) => panic!("{}", err),
             };
         }
 
         match state {
-            GameState::ProtonNotInstalled => {
+            GameState::WineNotInstalled => {
                 let release;
-                if utils::use_latest("Do you want to install latest version of Proton GE or a specific version of it?") {
-                        release = 0;
-                    } else {
-                        release = utils::choose_release_version(
-                            PROTON_DEV,
-                            PROTON_REPO,
-                            "Please, select a version of Proton GE to install.",
-                        )
-                        .await
-                        .expect("Failed to fetch proton version!");
-                    }
+                if utils::use_latest(
+                    "Do you want to install latest version of wine GE or a specific version of it?",
+                ) {
+                    release = 0;
+                } else {
+                    release = utils::choose_release_version(
+                        WINE_DEV,
+                        WINE_REPO,
+                        "Please, select a version of wine GE to install.",
+                    )
+                    .await
+                    .expect("Failed to fetch wine version!");
+                }
 
-                info!("Proton not installed, installing it...");
-                proton_component = Some(
+                info!("Wine not installed, installing it...");
+                wine_component = Some(
                     GameManager::install_wine(
                         GameConfig::get_config_directory().await,
                         release,
                         Some(DownloadReporter::create(false)),
                     )
                     .await
-                    .expect("Failed to install Wine"),
+                    .expect("Failed to install wine"),
                 );
-                info!("Proton installed");
+                info!("wine installed");
             }
             GameState::DXVKNotInstalled => {
                 let release;
@@ -84,9 +86,9 @@ pub async fn run(
                 }
 
                 info!("DXVK not installed, installing it...");
-                debug!("{:?}", proton_component);
+                debug!("{:?}", wine_component);
                 GameManager::install_dxvk(
-                    &proton.clone().unwrap(),
+                    &wine.clone().unwrap(),
                     GameConfig::get_config_directory().await,
                     release,
                     Some(DownloadReporter::create(false)),
@@ -97,14 +99,14 @@ pub async fn run(
             }
             GameState::FontNotInstalled => {
                 info!("Fonts not installed, installing it...");
-                GameManager::install_font(&proton.clone().unwrap(), None::<Arc<DownloadReporter>>)
+                GameManager::install_font(&wine.clone().unwrap(), None::<Arc<DownloadReporter>>)
                     .await
                     .expect("Failed to install fonts");
                 info!("Fonts installed");
             }
             GameState::DependecieNotInstalled => {
                 info!("Dependecies not installed, installing it...");
-                GameManager::install_dependencies(&proton.clone().unwrap())
+                GameManager::install_dependencies(&wine.clone().unwrap())
                     .await
                     .expect("Failed to install dependecies");
                 info!("Dependecies installed");
@@ -167,9 +169,9 @@ pub async fn run(
     }
 
     info!("Starting game...");
-    debug!("{:?}", proton);
+    debug!("{:?}", wine);
     GameManager::start_game(
-        &proton.unwrap(),
+        &wine.unwrap(),
         GameConfig::get_game_dir()
             .await
             .expect("Failed to start game, the game directory was not found"),

--- a/babylonia-terminal-sdk/Cargo.toml
+++ b/babylonia-terminal-sdk/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
 tar = "0.4.40"
 tokio = { version = "1.37.0", features = ["fs"] }
+whatadistro = "0.1.0"
 wincompatlib = { version = "0.7.5", features = [
     "dxvk",
     "wine-bundles",

--- a/babylonia-terminal-sdk/Cargo.toml
+++ b/babylonia-terminal-sdk/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1.37.0", features = ["fs"] }
 wincompatlib = { version = "0.7.5", features = [
     "dxvk",
     "wine-bundles",
-    "wine-proton",
     "wine-fonts",
     "winetricks",
 ] }
+xz2 = "0.1.7"

--- a/babylonia-terminal-sdk/src/components/dxvk_component.rs
+++ b/babylonia-terminal-sdk/src/components/dxvk_component.rs
@@ -55,12 +55,7 @@ impl<'a> ComponentDownloader for DXVKComponent<'a> {
 
         Self::uncompress(file_output.clone(), self.path.clone()).await?;
 
-        let wine_prefix = self // wine take the data/wine/pfx prefix, but we want the data/wine prefix
-            .wine
-            .clone()
-            .with_prefix(self.wine.prefix.parent().unwrap());
-
-        wine_prefix
+        self.wine
             .install_dxvk(self.path.clone(), InstallParams::default())
             .expect("Failed to installed DXVK");
 

--- a/babylonia-terminal-sdk/src/components/dxvk_component.rs
+++ b/babylonia-terminal-sdk/src/components/dxvk_component.rs
@@ -55,12 +55,12 @@ impl<'a> ComponentDownloader for DXVKComponent<'a> {
 
         Self::uncompress(file_output.clone(), self.path.clone()).await?;
 
-        let wine_with_proton_prefix = self // wine take the data/wine/pfx prefix, but we want the data/wine prefix
+        let wine_prefix = self // wine take the data/wine/pfx prefix, but we want the data/wine prefix
             .wine
             .clone()
             .with_prefix(self.wine.prefix.parent().unwrap());
 
-        wine_with_proton_prefix
+        wine_prefix
             .install_dxvk(self.path.clone(), InstallParams::default())
             .expect("Failed to installed DXVK");
 

--- a/babylonia-terminal-sdk/src/components/mod.rs
+++ b/babylonia-terminal-sdk/src/components/mod.rs
@@ -1,4 +1,4 @@
 pub mod component_downloader;
 pub mod dxvk_component;
 pub mod game_component;
-pub mod proton_component;
+pub mod wine_component;

--- a/babylonia-terminal-sdk/src/components/wine_component.rs
+++ b/babylonia-terminal-sdk/src/components/wine_component.rs
@@ -111,6 +111,7 @@ impl WineComponent {
         debug!("Wine binary path : {:?}", wine_bin_location);
 
         let mut wine = wincompatlib::prelude::Wine::from_binary(wine_bin_location);
+        wine.prefix = prefix.clone();
 
         wine.init_prefix(Some(prefix)).unwrap();
 

--- a/babylonia-terminal-sdk/src/components/wine_component.rs
+++ b/babylonia-terminal-sdk/src/components/wine_component.rs
@@ -6,37 +6,37 @@ use std::{
 };
 
 use downloader::{progress::Reporter, Downloader};
-use flate2::read::GzDecoder;
 use log::debug;
 use tar::Archive;
 use wincompatlib::wine::ext::WineBootExt;
+use xz2::read::XzDecoder;
 
 use super::component_downloader::ComponentDownloader;
 use crate::utils::github_requester::GithubRequester;
 
-pub static PROTON_DEV: &str = "GloriousEggroll";
-pub static PROTON_REPO: &str = "proton-ge-custom";
+pub static WINE_DEV: &str = "Kron4ek";
+pub static WINE_REPO: &str = "Wine-Builds";
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct ProtonComponent {
+pub struct WineComponent {
     path: PathBuf,
     github_release_index: usize,
 }
 
-impl GithubRequester for ProtonComponent {
+impl GithubRequester for WineComponent {
     fn set_github_release_index(&mut self, new_release_index: usize) {
         self.github_release_index = new_release_index;
     }
 }
 
-impl ComponentDownloader for ProtonComponent {
+impl ComponentDownloader for WineComponent {
     async fn install<P: Reporter + 'static>(&self, progress: Option<Arc<P>>) -> anyhow::Result<()> {
         let file_output = self
             .download(
                 &self
                     .path
                     .parent()
-                    .expect("Failed to get the parent directory of Wine")
+                    .expect("Failed to get the parent directory of wine")
                     .to_path_buf(),
                 progress,
             )
@@ -52,7 +52,7 @@ impl ComponentDownloader for ProtonComponent {
         progress: Option<Arc<P>>,
     ) -> anyhow::Result<PathBuf> {
         let release =
-            Self::get_github_release_version(PROTON_DEV, PROTON_REPO, self.github_release_index)
+            Self::get_github_release_version(WINE_DEV, WINE_REPO, self.github_release_index)
                 .await?;
 
         let asset = release
@@ -79,14 +79,15 @@ impl ComponentDownloader for ProtonComponent {
     async fn uncompress(file: PathBuf, new_directory_name: PathBuf) -> anyhow::Result<()> {
         tokio::task::spawn_blocking(move || {
             let tar_xz = File::open(file.clone()).unwrap();
-            let tar = GzDecoder::new(tar_xz);
+            let tar = XzDecoder::new(tar_xz);
             let mut archive = Archive::new(tar);
             archive.unpack(new_directory_name.parent().unwrap())?;
             remove_file(file.clone())?;
             rename(
-                file.to_str().unwrap().strip_suffix(".tar.gz").unwrap(),
+                file.to_str().unwrap().strip_suffix(".tar.xz").unwrap(),
                 new_directory_name,
             )?;
+            debug!("???5");
 
             Ok::<(), anyhow::Error>(())
         })
@@ -96,49 +97,47 @@ impl ComponentDownloader for ProtonComponent {
     }
 }
 
-impl ProtonComponent {
+impl WineComponent {
     pub fn new(path: PathBuf) -> Self {
-        ProtonComponent {
-            path: path.join("proton"),
+        WineComponent {
+            path: path.join("wine"),
             github_release_index: 0,
         }
     }
 
-    pub fn init_proton(&self) -> Result<wincompatlib::prelude::Proton, String> {
+    pub fn init_wine(&self) -> Result<wincompatlib::prelude::Wine, String> {
         let prefix = self.path.parent().unwrap().join("data");
+        let wine_bin_location = self.path.join("bin/wine");
+        debug!("Initializing prefix with -> {:?}", prefix);
+        debug!("Wine binary path : {:?}", wine_bin_location);
 
-        let mut proton =
-            wincompatlib::prelude::Proton::new(self.path.clone(), Some(prefix.clone()));
-        let steam_location = Self::get_steam_location()?;
+        let mut wine = wincompatlib::prelude::Wine::from_binary(wine_bin_location);
 
-        debug!("Steam location used -> {:?}", steam_location);
+        wine.init_prefix(Some(prefix)).unwrap();
 
-        proton.steam_client_path = Some(steam_location);
-        proton.init_prefix(Some(prefix)).unwrap();
-
-        Ok(proton)
+        Ok(wine)
     }
 
-    fn get_steam_location() -> Result<PathBuf, String> {
-        let specified_steam_location = std::env::var("BT_STEAM_CLIENT_PATH");
-        if let Ok(location) = specified_steam_location {
-            return Ok(PathBuf::from(location));
-        }
+    //fn get_steam_location() -> Result<PathBuf, String> {
+    //    let specified_steam_location = std::env::var("BT_STEAM_CLIENT_PATH");
+    //    if let Ok(location) = specified_steam_location {
+    //        return Ok(PathBuf::from(location));
+    //    }
 
-        let location_to_check = [
-            dirs::home_dir().unwrap().join(".steam/steam"),
-            dirs::home_dir()
-                .unwrap()
-                .join(".var/app/com.valvesoftware.Steam/steam"), // for the flatpak version of steam
-        ];
+    //    let location_to_check = [
+    //        dirs::home_dir().unwrap().join(".steam/steam"),
+    //        dirs::home_dir()
+    //            .unwrap()
+    //            .join(".var/app/com.valvesoftware.Steam/steam"), // for the flatpak version of steam
+    //    ];
 
-        for location in location_to_check {
-            if location.exists() {
-                return Ok(location);
-            }
-        }
+    //    for location in location_to_check {
+    //        if location.exists() {
+    //            return Ok(location);
+    //        }
+    //    }
 
-        debug!("Can't find steam installation");
-        Err(String::from_str("We can't find your steam installation, please install steam in '~/.steam/steam' or specify your steam installation").unwrap())
-    }
+    //    debug!("Can't find steam installation");
+    //    Err(String::from_str("We can't find your steam installation, please install steam in '~/.steam/steam' or specify your steam installation").unwrap())
+    //}
 }

--- a/babylonia-terminal-sdk/src/components/wine_component.rs
+++ b/babylonia-terminal-sdk/src/components/wine_component.rs
@@ -87,7 +87,6 @@ impl ComponentDownloader for WineComponent {
                 file.to_str().unwrap().strip_suffix(".tar.xz").unwrap(),
                 new_directory_name,
             )?;
-            debug!("???5");
 
             Ok::<(), anyhow::Error>(())
         })

--- a/babylonia-terminal-sdk/src/game_config.rs
+++ b/babylonia-terminal-sdk/src/game_config.rs
@@ -18,6 +18,7 @@ pub struct GameConfig {
     pub is_game_installed: bool,
     pub is_game_patched: bool,
     pub launch_options: Option<String>,
+    pub launcher_version: Option<String>,
 }
 
 impl GameConfig {
@@ -100,6 +101,7 @@ impl Default for GameConfig {
             is_game_installed: false,
             is_game_patched: false,
             launch_options: None,
+            launcher_version: Some(env!("CARGO_PKG_VERSION").to_string()),
         }
     }
 }

--- a/babylonia-terminal-sdk/src/game_manager.rs
+++ b/babylonia-terminal-sdk/src/game_manager.rs
@@ -87,10 +87,6 @@ impl GameManager {
     where
         P: Reporter + 'static,
     {
-        let wine_prefix = wine // wine take the data/wine/pfx prefix, but we want the data/wine prefix
-            .clone()
-            .with_prefix(wine.prefix.parent().unwrap());
-
         let max = 1;
 
         if let Some(p) = &progress {
@@ -99,7 +95,7 @@ impl GameManager {
 
         notify_fonts_progress(0, max, &progress);
 
-        wine_prefix.install_font(Font::Arial)?;
+        wine.install_font(Font::Arial)?;
         notify_fonts_progress(1, max, &progress);
 
         let mut config = GameConfig::get_config().await;
@@ -110,11 +106,7 @@ impl GameManager {
     }
 
     pub async fn install_dependencies(wine: &Wine) -> anyhow::Result<()> {
-        let wine_prefix = wine // wine take the data/wine/pfx prefix, but we want the data/wine prefix
-            .clone()
-            .with_prefix(wine.prefix.parent().unwrap());
-
-        let winetricks = Winetricks::from_wine("/bin/winetricks", wine_prefix);
+        let winetricks = Winetricks::from_wine("/bin/winetricks", wine);
         //winetricks.install("corefonts")?;
         let mut child = winetricks.install("vcrun2022")?;
 

--- a/babylonia-terminal-sdk/src/game_manager.rs
+++ b/babylonia-terminal-sdk/src/game_manager.rs
@@ -16,7 +16,7 @@ use wincompatlib::prelude::*;
 use crate::{
     components::{
         component_downloader::ComponentDownloader, dxvk_component::DXVKComponent,
-        game_component::GameComponent, proton_component::ProtonComponent,
+        game_component::GameComponent, wine_component::WineComponent,
     },
     game_config::GameConfig,
     game_patcher,
@@ -46,11 +46,11 @@ impl GameManager {
         config_dir: PathBuf,
         release_index: usize,
         progress: Option<Arc<P>>,
-    ) -> anyhow::Result<ProtonComponent>
+    ) -> anyhow::Result<WineComponent>
     where
         P: Reporter + 'static,
     {
-        let mut wine_component = ProtonComponent::new(config_dir);
+        let mut wine_component = WineComponent::new(config_dir);
         wine_component.set_github_release_index(release_index);
 
         wine_component.install(progress).await?;
@@ -63,7 +63,7 @@ impl GameManager {
     }
 
     pub async fn install_dxvk<P>(
-        proton: &Proton,
+        wine: &Wine,
         config_dir: PathBuf,
         release_index: usize,
         progress: Option<Arc<P>>,
@@ -71,7 +71,7 @@ impl GameManager {
     where
         P: Reporter + 'static,
     {
-        let mut dxvk_component = DXVKComponent::from_wine(proton.wine(), config_dir);
+        let mut dxvk_component = DXVKComponent::from_wine(wine, config_dir);
         dxvk_component.set_github_release_index(release_index);
 
         dxvk_component.install(progress).await?;
@@ -83,14 +83,13 @@ impl GameManager {
         Ok(())
     }
 
-    pub async fn install_font<P>(proton: &Proton, progress: Option<Arc<P>>) -> anyhow::Result<()>
+    pub async fn install_font<P>(wine: &Wine, progress: Option<Arc<P>>) -> anyhow::Result<()>
     where
         P: Reporter + 'static,
     {
-        let wine_with_proton_prefix = proton // wine take the data/wine/pfx prefix, but we want the data/wine prefix
-            .wine()
+        let wine_prefix = wine // wine take the data/wine/pfx prefix, but we want the data/wine prefix
             .clone()
-            .with_prefix(proton.wine().prefix.parent().unwrap());
+            .with_prefix(wine.prefix.parent().unwrap());
 
         let max = 1;
 
@@ -100,7 +99,7 @@ impl GameManager {
 
         notify_fonts_progress(0, max, &progress);
 
-        wine_with_proton_prefix.install_font(Font::Arial)?;
+        wine_prefix.install_font(Font::Arial)?;
         notify_fonts_progress(1, max, &progress);
 
         let mut config = GameConfig::get_config().await;
@@ -110,13 +109,12 @@ impl GameManager {
         Ok(())
     }
 
-    pub async fn install_dependencies(proton: &Proton) -> anyhow::Result<()> {
-        let wine_with_proton_prefix = proton // wine take the data/wine/pfx prefix, but we want the data/wine prefix
-            .wine()
+    pub async fn install_dependencies(wine: &Wine) -> anyhow::Result<()> {
+        let wine_prefix = wine // wine take the data/wine/pfx prefix, but we want the data/wine prefix
             .clone()
-            .with_prefix(proton.wine().prefix.parent().unwrap());
+            .with_prefix(wine.prefix.parent().unwrap());
 
-        let winetricks = Winetricks::from_wine("/bin/winetricks", wine_with_proton_prefix);
+        let winetricks = Winetricks::from_wine("/bin/winetricks", wine_prefix);
         //winetricks.install("corefonts")?;
         let mut child = winetricks.install("vcrun2022")?;
 
@@ -165,26 +163,26 @@ impl GameManager {
     }
 
     pub async fn start_game(
-        proton: &Proton,
+        wine: &Wine,
         game_dir: PathBuf,
         options: Option<String>,
         env_variables: Vec<EnvironmentVariable>,
         show_logs: bool,
     ) -> anyhow::Result<()> {
-        let proton_version = proton.wine().version()?;
+        let wine_version = wine.version()?;
         let binary_path = game_dir
             .join(get_game_name())
             .join(get_game_name_with_executable());
 
-        debug!("Wine version : {:?}", proton_version);
+        debug!("wine version : {:?}", wine_version);
 
         let mut child = if let Some(custom_command) = options {
-            Self::run(proton, binary_path, Some(custom_command), env_variables).await?
+            Self::run(wine, binary_path, Some(custom_command), env_variables).await?
         } else {
             if let Some(custom_command) = GameConfig::get_launch_options().await.unwrap() {
-                Self::run(proton, binary_path, Some(custom_command), env_variables).await?
+                Self::run(wine, binary_path, Some(custom_command), env_variables).await?
             } else {
-                Self::run(proton, binary_path, None, env_variables).await?
+                Self::run(wine, binary_path, None, env_variables).await?
             }
         }?;
 
@@ -205,7 +203,7 @@ impl GameManager {
                     .lines()
                     .inspect(|s| {
                         if let Ok(str) = s {
-                            info!("[Proton] > {}", str);
+                            info!("[wine] > {}", str);
                             stdout_save.push_str(str);
                         }
                     })
@@ -219,7 +217,7 @@ impl GameManager {
                     .lines()
                     .inspect(|s| {
                         if let Ok(str) = s {
-                            info!("[Proton] > {}", str);
+                            info!("[wine] > {}", str);
                             stderr_save.push_str(str);
                         }
                     })
@@ -292,20 +290,20 @@ impl GameManager {
     }
 
     async fn run(
-        proton: &Proton,
+        wine: &Wine,
         binary_path: PathBuf,
         custom_command: Option<String>,
         env_variables: Vec<EnvironmentVariable>,
     ) -> anyhow::Result<Result<Child, std::io::Error>> {
         let mut command: Vec<&str> = vec![];
 
-        let proton_path = GameConfig::get_config_directory()
+        let wine_path = GameConfig::get_config_directory()
             .await
-            .join("proton")
-            .join("proton");
+            .join("wine")
+            .join("wine");
 
-        command.push(proton.python.to_str().unwrap());
-        command.push(proton_path.to_str().unwrap());
+        //command.push(wine.python.to_str().unwrap());
+        command.push(wine_path.to_str().unwrap());
         command.push("run");
         command.push(binary_path.to_str().unwrap());
 
@@ -337,8 +335,8 @@ impl GameManager {
 
         Ok(Command::new(command[0])
             .args(&command[1..command.len()])
-            .envs(proton.get_envs())
-            .env("PROTON_LOG", "1")
+            .envs(wine.get_envs())
+            .env("Wine_LOG", "1")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())

--- a/babylonia-terminal-sdk/src/game_patcher.rs
+++ b/babylonia-terminal-sdk/src/game_patcher.rs
@@ -58,29 +58,29 @@ pub async fn patch_game(game_dir: PathBuf) -> anyhow::Result<()> {
 
     // section to replace the executable with the patched one
 
-    let executable_path = game_dir
-        .join(get_game_name())
-        .join(get_game_name_with_executable());
+    //let executable_path = game_dir
+    //    .join(get_game_name())
+    //    .join(get_game_name_with_executable());
 
-    debug!("{:?}", executable_path);
+    //debug!("{:?}", executable_path);
 
-    if executable_path.exists() {
-        remove_file(executable_path.clone()).await?;
-    }
+    //if executable_path.exists() {
+    //    remove_file(executable_path.clone()).await?;
+    //}
 
-    match PatchedGameExecutable::get_exectable() {
-        Some(exe) => {
-            let mut file = File::create(executable_path).await?;
+    //match PatchedGameExecutable::get_exectable() {
+    //    Some(exe) => {
+    //        let mut file = File::create(executable_path).await?;
 
-            let data: Result<Vec<_>, _> = exe.data.bytes().collect();
-            let data = data.expect("Unable to read executable data");
+    //        let data: Result<Vec<_>, _> = exe.data.bytes().collect();
+    //        let data = data.expect("Unable to read executable data");
 
-            file.write_all(&data).await?;
-        }
-        None => anyhow::bail!(
-            "Game executable not included in the binary! Please report this to the developer!"
-        ),
-    }
+    //        file.write_all(&data).await?;
+    //    }
+    //    None => anyhow::bail!(
+    //        "Game executable not included in the binary! Please report this to the developer!"
+    //    ),
+    //}
 
     let mut config = GameConfig::get_config().await;
     config.is_game_patched = true;

--- a/babylonia-terminal-sdk/src/game_state.rs
+++ b/babylonia-terminal-sdk/src/game_state.rs
@@ -2,7 +2,7 @@ use crate::{game_config::GameConfig, utils::kuro_prod_api::GameInfo};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum GameState {
-    ProtonNotInstalled,
+    WineNotInstalled,
     DXVKNotInstalled,
     FontNotInstalled,
     DependecieNotInstalled,
@@ -17,7 +17,7 @@ impl GameState {
         let config = GameConfig::get_config().await;
 
         if !config.is_wine_installed {
-            return Ok(GameState::ProtonNotInstalled);
+            return Ok(GameState::WineNotInstalled);
         }
 
         if !config.is_dxvk_installed {

--- a/babylonia-terminal-sdk/src/utils/mod.rs
+++ b/babylonia-terminal-sdk/src/utils/mod.rs
@@ -1,3 +1,10 @@
+use std::io;
+
+use log::debug;
+use tokio::fs::remove_dir_all;
+
+use crate::game_config::GameConfig;
+
 pub mod github_requester;
 pub mod kuro_prod_api;
 
@@ -7,4 +14,12 @@ pub fn get_game_name() -> String {
 
 pub fn get_game_name_with_executable() -> String {
     format!("{}.exe", get_game_name())
+}
+
+pub async fn remove_setup() -> io::Result<()> {
+    let config_dir = GameConfig::get_config_directory().await;
+
+    debug!("Current setup directory : {:?}", config_dir);
+
+    remove_dir_all(config_dir).await
 }


### PR DESCRIPTION
normaly this update should fix everything wrong with the launcher, here's the following fixes :
1. Game download has been fix
2. The launcher use Wine instead of Proton-GE now
3. The launcher should automatically make the transition between Wine and Proton (in progress)

After that I only need to finish the flatpak release